### PR TITLE
Added OpenMP directives to KUBO

### DIFF
--- a/KUBO/src/CPAConductivityModule.F90
+++ b/KUBO/src/CPAConductivityModule.F90
@@ -558,7 +558,7 @@ contains
        enddo
      enddo
 
-     if (k_loc <= NumKsOnMyProc - NumRedunKs .or. NumPEinKGroup == 0) then
+     if (k_loc <= NumKsOnMyProc - NumRedunKs .or. MyPEinKGroup == 0) then
        if (nrot > 1) then
          do irot = 1, nrot
            w0 = CZERO

--- a/architecture/ascent-nvhpc-ibmmpi
+++ b/architecture/ascent-nvhpc-ibmmpi
@@ -56,7 +56,7 @@ CPPFLAGS    =
 
 CFLAGS      = -O3
 CXXFLAGS    = -O3 -std=c++14
-OPT_OPENMP  = -fopenmp
+OPT_OPENMP  = -fopenmp -mp=gpu -Minfo=mp,accel
 # FFLAGS      = -O3 -Mbounds -traceback -Mchkptr -Mchkstk
 FFLAGS      = -O3 $(OPT_OPENMP)
 F77FLAGS    = -O3 $(OPT_OPENMP)

--- a/architecture/summit-gnu-cuda
+++ b/architecture/summit-gnu-cuda
@@ -25,7 +25,7 @@ LIBXC_PATH  =
 FFTW_PATH   = $(OLCF_FFTW_ROOT)
 # P3DFFT_PATH = /gpfs/alpine/proj-shared/mat020/p3dfft-2.7.9/GNU
 P3DFFT_PATH = 
-LUA_PATH    =
+LUA_PATH    =  /usr/bin/lua
 LIBS       += -L${OLCF_ESSL_ROOT}/lib64 -lessl -L$(OLCF_NETLIB_SCALAPACK_ROOT)/lib -lscalapack -L$(OLCF_CUDA_ROOT)/lib64 -lcudart -lcuda -lcublas
 ADD_LIBS   += -lgfortran -lm -lstdc++
 
@@ -55,8 +55,8 @@ CPPFLAGS    =
 
 CFLAGS      = -O3
 CXXFLAGS    = -O3 -std=c++14
-FFLAGS      = -O3
-F77FLAGS    = -O3
+FFLAGS      = -O3 -fopenmp
+F77FLAGS    = -O3 -fopenmp
 OPT_OPENMP  = -fopenmp
 
 LD_FLAGS    =


### PR DESCRIPTION
1. OpenMP directives were added to the double tau matrix integration in the conductivity calculation (CPAConductivityModule.F90)

2. ascent-nvhpc-ibmmpi was modified to include FFLAGS= -O3 -fopenmp -mp=gpu -Minfo=mp,accel in order to tell nvhpc compiler to allow GPU offloading

3. summit-gnu-cuda was modified to include FFLAGS = -O3 -fopenmp in order to tell gcc to do OpenMP parallelism.