### PR TITLE
Fixed missing dependency issue in KUBO makefile

### DIFF
--- a/KUBO/src/Makefile
+++ b/KUBO/src/Makefile
@@ -22,7 +22,8 @@ BasicRoutines = \
 ../../MST/bin/rdin_old_infotable.o \
 ../../MST/bin/rdin_old_infoevec.o \
 ../../MST/bin/getValueAtPosi.o \
-../../MST/bin/lattice.o
+../../MST/bin/lattice.o \
+../../MST/bin/averageAcrossProcesses.o
 
 AppModules = \
 ../../MST/bin/InputModule.o \


### PR DESCRIPTION
averageAcrossProcesses.o had to be added to KUBO makefile, without it there will be dependency issues in PotentialGenerationModule when KUBO is compiled