### PR TITLE
Commented out checkinTiming line from SSSolverModule

### DIFF
--- a/MST/src/SSSolverModule.F90
+++ b/MST/src/SSSolverModule.F90
@@ -2118,7 +2118,7 @@ use MPPModule, only : MyPE, syncAllPEs
    endif
 !
 !  -------------------------------------------------------------------
-   call checkinTiming('solveSingleScattering',getTime()-t_start)
+!  call checkinTiming('solveSingleScattering',getTime()-t_start)
 !  -------------------------------------------------------------------
 !
    end subroutine solveSingleScattering


### PR DESCRIPTION
The checkinTiming line is causing Segfault when KUBO is run

forrtl: severe (174): SIGSEGV, segmentation fault occurred
Image              PC                Routine            Line        Source             
libifcore.so.5     0000145CCB7D30C9  for__signal_handl     Unknown  Unknown
libpthread-2.27.s  0000145CC1CEC980  Unknown               Unknown  Unknown
kubo               000000000143B877  timermodule_mp_ch         238  TimerModule.F90
kubo               0000000000A97CB2  sssolvermodule_mp        2121  SSSolverModule.F90
kubo               0000000000B3CB6E  sssolvermodule_mp         944  SSSolverModule.F90
kubo               0000000000413A5A  MAIN__                    623  kubo.F90
kubo               000000000040AD42  Unknown               Unknown  Unknown
libc-2.27.so       0000145CC156CC87  __libc_start_main     Unknown  Unknown
kubo               000000000040AC2A  Unknown               Unknown  Unknown

Temporary solution of commenting that line out since it does not affect the main code, it only tracks timing.