### PR TITLE
fix memory error with variable tau00 in cusolver_invwhole_c_

### DIFF
--- a/MST/Accelerator/cusolver_invwhole_c.cu
+++ b/MST/Accelerator/cusolver_invwhole_c.cu
@@ -22,11 +22,14 @@ float time_copyin=0;
 float time_copyout=0;
 float time_compute=0;
 
-double _Complex tau00[*m][*m];
+// LFu: fix segmentation fault when allocating the array
+double _Complex *tau00;
+tau00 = (double _Complex *) malloc(sizeof(double _Complex) * *m * *m);
+
 for (int i=0;i<*m;i++){
 for (int j=0;j<*m;j++){
-	if (i==j){tau00[i][j]={1,0};}
-        else{tau00[i][j]={0,0};}
+	if (i==j){tau00[i * *m + j]={1,0};}
+        else{tau00[i * *m + j]={0,0};}
 }
 }
 
@@ -118,4 +121,7 @@ cudaEventElapsedTime(&time_copyout, start, stop);
 //clean up
 cusolverDnDestroy(cusolverHandle);
 cudaFree(workArray);
+
+// LFu: clean up tau00
+free(tau00);
 }


### PR DESCRIPTION
The recent updated GPU accelerated code encounterd a SegFault when running LSMS in Muffin-Tin potential on Intel platform with Nvidia CUDA v12.0 (material was a 2 atom cell of Cu and Zu with B2 structure). The error was caused by variable `tau00` during its allocation and copying to GPU in function `cusolver_invwhole_c_`. The error was reportedly absent when building with CUDA v11.

Here I propos a straightforward solution to treat the variable as a 1-dimentional array pointer so that the memory is alocated continuously and can be easily copied to target GPU. (2D nested array pointer can not gurrantee continuous memory allocation between rows and might cause memory error when using `cudaMemcpy`.)