### PR TITLE
Changed MaxComponents values to 20

### DIFF
--- a/MST/src/readPositionData.F90
+++ b/MST/src/readPositionData.F90
@@ -69,7 +69,7 @@
    real (kind=RealKind), pointer :: AtomPosition(:,:), p_AtomPosition(:)
    real (kind=RealKind), pointer :: BravaisLatticeVec(:,:)
 !
-   integer (kind=IntKind), parameter :: MaxComponents = 8 ! This maximum should be more than enough.
+   integer (kind=IntKind), parameter :: MaxComponents = 20 ! This maximum should be more than enough.
    character (len=MaxLenOfAtomName) :: component
    type AlloyStruct
       integer (kind=IntKind) :: NumComponents


### PR DESCRIPTION
Currently MaxComponents is 8, which is sufficient for non-spin-polarized alloys, but if DLM is used then this effectively becomes halved. To allow for more than 4-element alloy DLM calculation, MaxComponents has been shifted to 20.

Ultimately, I think it's a good idea to treat MaxComponents as a default value and replace it with a user-defined value during the run. 